### PR TITLE
jta library update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# IDE files and directories
+.classpath
+.project
+.settings
+.idea
+
+# Maven build directory
+target/

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -7,10 +7,8 @@
   </parent>
 	
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>com.eaglegenomics.simlims</groupId>
 	<artifactId>simlims-core</artifactId>
 	<packaging>jar</packaging>
-	<version>0.0.5-SNAPSHOT</version>
 	<name>Simlims Core</name>
 	<url>http://maven.apache.org</url>
 	<build>

--- a/demoprotocol/pom.xml
+++ b/demoprotocol/pom.xml
@@ -8,10 +8,8 @@
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.eaglegenomics.simlims</groupId>
     <artifactId>simlims-demoprotocol</artifactId>
     <packaging>jar</packaging>
-    <version>0.0.5-SNAPSHOT</version>
     <name>Simlims Demo Protocol</name>
     <url>http://maven.apache.org</url>
     <build>

--- a/hibernatestore/pom.xml
+++ b/hibernatestore/pom.xml
@@ -8,10 +8,8 @@
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.eaglegenomics.simlims</groupId>
     <artifactId>simlims-hibernatestore</artifactId>
     <packaging>jar</packaging>
-    <version>0.0.5-SNAPSHOT</version>
     <name>Simlims Hibernate Store</name>
     <url>http://maven.apache.org</url>
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.6.0</version>
                 <configuration>
                     <source>1.6</source>
                     <target>1.6</target>

--- a/runner/pom.xml
+++ b/runner/pom.xml
@@ -8,9 +8,7 @@
   </parent>
 	
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>com.eaglegenomics.simlims</groupId>
 	<artifactId>simlims-runner</artifactId>
-	<version>0.0.5-SNAPSHOT</version>
   <name>Simlims Runner</name>
 	<build>
 		<plugins>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -8,9 +8,7 @@
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.eaglegenomics.simlims</groupId>
     <artifactId>simlims-spring</artifactId>
-    <version>0.0.5-SNAPSHOT</version>
     <name>Simlims Spring IoC</name>
     <build>
         <plugins>
@@ -26,6 +24,11 @@
         </plugins>
     </build>
     <dependencies>
+        <dependency>
+            <groupId>javax.transaction</groupId>
+            <artifactId>jta</artifactId>
+            <version>1.1</version>
+        </dependency>
         <dependency>
             <groupId>com.eaglegenomics.simlims</groupId>
             <artifactId>simlims-core</artifactId>

--- a/sqlstore/pom.xml
+++ b/sqlstore/pom.xml
@@ -8,10 +8,8 @@
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.eaglegenomics.simlims</groupId>
     <artifactId>simlims-sqlstore</artifactId>
     <packaging>jar</packaging>
-    <version>0.0.5-SNAPSHOT</version>
     <name>Simlims SQL Store</name>
     <url>http://maven.apache.org</url>
     <build>


### PR DESCRIPTION
Simlims would not complile as I was unable to download the jta library via maven. Updating the jta version allowed the maven download to work and simlims compiled.

Update version of jta to 1.1. Previous 1.0.1B version would not download via maven.
Removed duplicate groupId and version from pom files.
Included missing maven-compiler-plugin version.
Ignoring maven target and ide config files.